### PR TITLE
Avoiding unnecessary try-catch, fixing argparse argument formatters

### DIFF
--- a/blindtex/converter/converter.py
+++ b/blindtex/converter/converter.py
@@ -4,9 +4,9 @@ import argparse
 import parser as parser
 
 myArgumentParser = argparse.ArgumentParser()
-myArgumentParser.add_argument('formula', type=str, help ='The formula to be converted')
-myArgumentParser.add_argument('-lit', '--literal', help="Display the formula in literal form.",action="store_true")
-myArgumentParser.add_argument('-nvda','--nvda', help='Converts with the label math.', action = "store_true")
+myArgumentParser.add_argument('-f', '--formula', type=str, help ='The formula to be converted')
+myArgumentParser.add_argument('-l', '--literal', help="Display the formula in literal form.", action="store_true")
+myArgumentParser.add_argument('-n', '--nvda', help='Converts with the label math.', action = "store_true")
 
 args = myArgumentParser.parse_args()
 
@@ -19,7 +19,3 @@ elif(args.nvda):
 else:
 	parser.OPTION = 0
 	print(parser.convert(args.formula))
-
-
-
-

--- a/blindtex/converter/lexer.py
+++ b/blindtex/converter/lexer.py
@@ -18,11 +18,11 @@ states = (('command', 'exclusive'),('anything','exclusive'),)
 # Put global scope 
 #dictOfDicts = dict()
 
-try:
-        with open(os.path.join('converter','dicts','regexes.json'), 'r') as myFile:
-            dictOfDicts = json.load(myFile)
-except IOError:
-	print('[Error] File could not be opened.')
+# try:
+with open(os.path.join('converter','dicts','regexes.json'), 'r') as myFile:
+    dictOfDicts = json.load(myFile)
+# except IOError:
+	# print('[Error] File could not be opened.')
 
 # Put variable out of the scope
 #dictOfDicts = json.load(myFile)

--- a/blindtex/converter/lexer.py
+++ b/blindtex/converter/lexer.py
@@ -14,6 +14,9 @@ tokens = ('CHAR', 'SUP', 'SUB','BEGINBLOCK','ENDBLOCK', 'ORD', 'FRAC', 'ROOT', '
           'BINOM', 'PMOD','PHANTOM','TEXT','LABEL','ANYTHING','ARRAYTEXT', 'USER')
 
 states = (('command', 'exclusive'),('anything','exclusive'),)
+        
+# Put dictOfDicts into global scope
+dictOfDicts = None
 
 try:
         myFile = open(os.path.join('converter','dicts','regexes.json'), 'r')

--- a/blindtex/converter/lexer.py
+++ b/blindtex/converter/lexer.py
@@ -15,14 +15,11 @@ tokens = ('CHAR', 'SUP', 'SUB','BEGINBLOCK','ENDBLOCK', 'ORD', 'FRAC', 'ROOT', '
 
 states = (('command', 'exclusive'),('anything','exclusive'),)
         
-# Put global scope 
-#dictOfDicts = dict()
-
-# try:
-with open(os.path.join('converter','dicts','regexes.json'), 'r') as myFile:
-    dictOfDicts = json.load(myFile)
-# except IOError:
-	# print('[Error] File could not be opened.')
+try:
+    with open(os.path.join('converter','dicts','regexes.json'), 'r') as myFile:
+        dictOfDicts = json.load(myFile)
+except:
+    print('[Error] File could not be opened.')
 
 # Put variable out of the scope
 #dictOfDicts = json.load(myFile)

--- a/blindtex/converter/lexer.py
+++ b/blindtex/converter/lexer.py
@@ -15,16 +15,18 @@ tokens = ('CHAR', 'SUP', 'SUB','BEGINBLOCK','ENDBLOCK', 'ORD', 'FRAC', 'ROOT', '
 
 states = (('command', 'exclusive'),('anything','exclusive'),)
         
-# Put dictOfDicts into global scope
-dictOfDicts = None
-
 try:
-        myFile = open(os.path.join('converter','dicts','regexes.json'), 'r')
+#        myFile = open(os.path.join('converter','dicts','regexes.json'), 'r')
+        with open(os.path.join('converter','dicts','regexes.json'), 'r') as myFile:
+            dictOfDicts = json.load(myFile)
         #myFile = open('regexes.json')
-        dictOfDicts = json.load(myFile)
-        myFile.close()
+        #dictOfDicts = json.load(myFile)
+#        myFile.close()
 except IOError:
 	print('File could not be oppened.')
+
+# Put variable out of the scope
+#dictOfDicts = json.load(myFile)
 
 
 literals = [ '!',"'",]

--- a/blindtex/converter/lexer.py
+++ b/blindtex/converter/lexer.py
@@ -15,15 +15,14 @@ tokens = ('CHAR', 'SUP', 'SUB','BEGINBLOCK','ENDBLOCK', 'ORD', 'FRAC', 'ROOT', '
 
 states = (('command', 'exclusive'),('anything','exclusive'),)
         
+# Put global scope 
+#dictOfDicts = dict()
+
 try:
-#        myFile = open(os.path.join('converter','dicts','regexes.json'), 'r')
         with open(os.path.join('converter','dicts','regexes.json'), 'r') as myFile:
             dictOfDicts = json.load(myFile)
-        #myFile = open('regexes.json')
-        #dictOfDicts = json.load(myFile)
-#        myFile.close()
 except IOError:
-	print('File could not be oppened.')
+	print('[Error] File could not be opened.')
 
 # Put variable out of the scope
 #dictOfDicts = json.load(myFile)

--- a/blindtex/converter/lexer.py
+++ b/blindtex/converter/lexer.py
@@ -14,16 +14,12 @@ tokens = ('CHAR', 'SUP', 'SUB','BEGINBLOCK','ENDBLOCK', 'ORD', 'FRAC', 'ROOT', '
           'BINOM', 'PMOD','PHANTOM','TEXT','LABEL','ANYTHING','ARRAYTEXT', 'USER')
 
 states = (('command', 'exclusive'),('anything','exclusive'),)
-        
-try:
-    with open(os.path.join('converter','dicts','regexes.json'), 'r') as myFile:
-        dictOfDicts = json.load(myFile)
-except:
-    print('[Error] File could not be opened.')
-
-# Put variable out of the scope
-#dictOfDicts = json.load(myFile)
-
+      
+# try:
+with open(os.path.join('blindtex','converter','dicts','regexes.json'), 'r') as myFile:
+    dictOfDicts = json.load(myFile)
+# except:
+    # print('[Error] File could not be opened.')
 
 literals = [ '!',"'",]
 


### PR DESCRIPTION
The `with ... as ...` statement avoids the need of exception catching when the file can't be accessed. On the other hand, there is no point in catching the exception since the following code strongly depends on the contents read from the file `regexes.json`. 

I also fixed the path to the regexes.jon file, this fixes part of the continuos integration problem, since several assertions fail.

Sorry for the long chain of commits, I'm a friend of storing every single change performed